### PR TITLE
Disable unused GitHub Pages workflows

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -2,10 +2,6 @@
 name: Deploy Jekyll with GitHub Pages dependencies preinstalled
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,10 +2,6 @@
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
-  push:
-    branches: ["main"]
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- remove automatic main branch triggers from the legacy GitHub Pages workflows so they only run manually

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc20e766488323a1aeee68578e90dd